### PR TITLE
fixing a typo in the command name

### DIFF
--- a/menus/atom-maven.cson
+++ b/menus/atom-maven.cson
@@ -18,7 +18,7 @@
         },
         {
           'label': 'mvn effective-pom'
-          'command': 'atom-maven:effectivePom'
+          'command': 'atom-maven:effective-pom'
         }
       ]
     ]


### PR DESCRIPTION
Made a quick fix to change `atom-maven:effectivePom` to `atom-maven:effective-pom` in the CSON file to match the command name defined in `atom-maven.js`.