### PR TITLE
Pass name of effective pom

### DIFF
--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -218,7 +218,7 @@ module.exports = {
       if (match.filePath.endsWith('pom.xml')) {
         ui.info(GENERATING_EFFECTIVE_POM);
         var maven = Maven.create(match.filePath);
-        maven.effectivePom();
+        maven.effectivePom(match.filePath.replace('pom.xml', 'effective.pom'));
       }
     });
   }


### PR DESCRIPTION
I updated the call to create the effective pom to pass in a hardcoded name of `effective.pom` to match the `getEffectivePom` function.  Testing it on my local install of Atom resulted in an effective pom being generated at the same level as pom.xml.