### PR TITLE
Dependency Plugin Build Classpath

### DIFF
--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -235,7 +235,7 @@ module.exports = {
             console.error(`exec error: ${error}`);
           } else {
             fs.readFile(cp, function (err, data) {
-              if(err) {
+              if (err) {
                 ui.error(err);
               }
               var target = '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;';

--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -223,9 +223,9 @@ module.exports = {
         maven.effectivePom();
       }
     });
-  }
+  },
 
-  dependencyTreeClasspath: funtion() {
+  dependencyTreeClasspath: function() {
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
         var cp = match.filePath.replace('pom.xml', '.classpath');

--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -39,7 +39,7 @@ module.exports = {
 
   classpathFileName: atom.config.get('atom-maven.classpathFileName'),
 
-  activate: function() {
+  activate: function () {
     const self = this;
     self.setup();
     atom.config.observe('atom-maven.classpathFileName', {}, () => {
@@ -52,14 +52,14 @@ module.exports = {
     atom.commands.add('atom-workspace', 'atom-maven:classpath', self.dependencyTreeClasspath);
   },
 
-  failWithUI: function(message, match, callback) {
+  failWithUI: function (message, match, callback) {
     return () => {
       ui.error(message + match.filePath, null, null, match.filePath, null);
       callback();
     };
   },
 
-  setup: function() {
+  setup: function () {
     var self = this;
 
     atom.workspace.scan(/<project.*/g, (match) => {
@@ -69,9 +69,9 @@ module.exports = {
         var maven = Maven.create(match.filePath);
         var lastPom = null;
 
-        var buildFailed = function() {
+        var buildFailed = function () {
           if (lastPom && pomUtils.hasDependencies(lastPom)) {
-            var notExistsCallback = function(err, dependency) {
+            var notExistsCallback = function (err, dependency) {
               if (err) {
                 console.error(err);
               } else {
@@ -107,7 +107,7 @@ module.exports = {
           maven.clean();
         });
 
-        var updateClasspath = function() {
+        var updateClasspath = function () {
           maven.effectivePom(self.getEffectivePom(match.filePath));
         };
         if (atom.config.get('generateClasspathsOnStartup') === true) {
@@ -134,7 +134,7 @@ module.exports = {
     }, 2e4);
   },
 
-  writeClasspath: function(cp, pom, self) {
+  writeClasspath: function (cp, pom, self) {
     var locations = self.initLocations() + self.getClasspathFromDependencies(pom, self);
     fs.writeFile(cp, locations, (err) => {
       if (err) {
@@ -143,19 +143,19 @@ module.exports = {
     });
   },
 
-  getClasspath: function(pomPath) {
+  getClasspath: function (pomPath) {
     return pomPath.replace('pom.xml', this.classpathFileName);
   },
 
-  getEffectivePom: function(pomPath) {
+  getEffectivePom: function (pomPath) {
     return pomPath.replace('pom.xml', 'effective.pom');
   },
 
-  initLocations: function() {
+  initLocations: function () {
     return '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;';
   },
 
-  getClasspathFromDependencies: function(pom) {
+  getClasspathFromDependencies: function (pom) {
     var locations = '';
     if (pomUtils.hasDependencies(pom)) {
       for (var dependency of pom.project.dependencies.dependency) {
@@ -166,7 +166,7 @@ module.exports = {
     return locations;
   },
 
-  displayDependencyError: function(classpathElement) {
+  displayDependencyError: function (classpathElement) {
     var xml = classpathElement.xml;
     var dependency = classpathElement.dependency;
     var file = classpathElement.file;
@@ -181,7 +181,7 @@ module.exports = {
     ui.error(message, lineNo, 0, file, preview);
   },
 
-  clean: function() {
+  clean: function () {
     console.info('atom-maven:clean invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -192,7 +192,7 @@ module.exports = {
     });
   },
 
-  install: function() {
+  install: function () {
     console.info('atom-maven:install invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -203,7 +203,7 @@ module.exports = {
     });
   },
 
-  test: function() {
+  test: function () {
     console.info('atom-maven:test invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -214,7 +214,7 @@ module.exports = {
     });
   },
 
-  effectivePom: function() {
+  effectivePom: function () {
     console.log('atom-maven:effective-pom invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -225,16 +225,16 @@ module.exports = {
     });
   },
 
-  dependencyTreeClasspath: function() {
+  dependencyTreeClasspath: function () {
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
         var cp = match.filePath.replace('pom.xml', '.classpath');
         var cmd = 'mvn dependency:build-classpath -f' + match.filePath + ' -Dmdep.outputFile=' + cp;
-        process.exec(cmd, function(error, stdout, stderr) {
+        process.exec(cmd, function (error, stdout, stderr) {
           if (error) {
             console.error(`exec error: ${error}`);
           } else {
-            fs.readFile(cp, function(err, data) {
+            fs.readFile(cp, function (err, data) {
               var target = '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;'
               var locations = target + data;
               fs.writeFile(cp, locations, (err) => {

--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -8,6 +8,7 @@ const pomUtils = require('./pom-utils');
 const fileUtils = require('./file-utils');
 const Maven = require('node-maven-api');
 const watch = require('node-watch');
+const process = require('child_process');
 
 const CONFIGURING_CLASSPATH_MSG = 'atom-maven is configuring your classpath';
 const BUILDING_PROJECT = 'atom-maven is building your project: ';
@@ -38,7 +39,7 @@ module.exports = {
 
   classpathFileName: atom.config.get('atom-maven.classpathFileName'),
 
-  activate: function () {
+  activate: function() {
     const self = this;
     self.setup();
     atom.config.observe('atom-maven.classpathFileName', {}, () => {
@@ -48,16 +49,17 @@ module.exports = {
     atom.commands.add('atom-workspace', 'atom-maven:install', self.install);
     atom.commands.add('atom-workspace', 'atom-maven:test', self.test);
     atom.commands.add('atom-workspace', 'atom-maven:effective-pom', self.effectivePom);
+    atom.commands.add('atom-workspace', 'atom-maven:classpath', self.dependencyTreeClasspath);
   },
 
-  failWithUI: function (message, match, callback) {
+  failWithUI: function(message, match, callback) {
     return () => {
       ui.error(message + match.filePath, null, null, match.filePath, null);
       callback();
     };
   },
 
-  setup: function () {
+  setup: function() {
     var self = this;
 
     atom.workspace.scan(/<project.*/g, (match) => {
@@ -67,9 +69,9 @@ module.exports = {
         var maven = Maven.create(match.filePath);
         var lastPom = null;
 
-        var buildFailed = function () {
+        var buildFailed = function() {
           if (lastPom && pomUtils.hasDependencies(lastPom)) {
-            var notExistsCallback = function (err, dependency) {
+            var notExistsCallback = function(err, dependency) {
               if (err) {
                 console.error(err);
               } else {
@@ -105,7 +107,7 @@ module.exports = {
           maven.clean();
         });
 
-        var updateClasspath = function () {
+        var updateClasspath = function() {
           maven.effectivePom(self.getEffectivePom(match.filePath));
         };
         if (atom.config.get('generateClasspathsOnStartup') === true) {
@@ -132,7 +134,7 @@ module.exports = {
     }, 2e4);
   },
 
-  writeClasspath: function (cp, pom, self) {
+  writeClasspath: function(cp, pom, self) {
     var locations = self.initLocations() + self.getClasspathFromDependencies(pom, self);
     fs.writeFile(cp, locations, (err) => {
       if (err) {
@@ -141,19 +143,19 @@ module.exports = {
     });
   },
 
-  getClasspath: function (pomPath) {
+  getClasspath: function(pomPath) {
     return pomPath.replace('pom.xml', this.classpathFileName);
   },
 
-  getEffectivePom: function (pomPath) {
+  getEffectivePom: function(pomPath) {
     return pomPath.replace('pom.xml', 'effective.pom');
   },
 
-  initLocations: function () {
+  initLocations: function() {
     return '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;';
   },
 
-  getClasspathFromDependencies: function (pom) {
+  getClasspathFromDependencies: function(pom) {
     var locations = '';
     if (pomUtils.hasDependencies(pom)) {
       for (var dependency of pom.project.dependencies.dependency) {
@@ -164,7 +166,7 @@ module.exports = {
     return locations;
   },
 
-  displayDependencyError: function (classpathElement) {
+  displayDependencyError: function(classpathElement) {
     var xml = classpathElement.xml;
     var dependency = classpathElement.dependency;
     var file = classpathElement.file;
@@ -179,7 +181,7 @@ module.exports = {
     ui.error(message, lineNo, 0, file, preview);
   },
 
-  clean: function () {
+  clean: function() {
     console.info('atom-maven:clean invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -190,7 +192,7 @@ module.exports = {
     });
   },
 
-  install: function () {
+  install: function() {
     console.info('atom-maven:install invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -201,7 +203,7 @@ module.exports = {
     });
   },
 
-  test: function () {
+  test: function() {
     console.info('atom-maven:test invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -212,7 +214,7 @@ module.exports = {
     });
   },
 
-  effectivePom: function () {
+  effectivePom: function() {
     console.log('atom-maven:effective-pom invoked');
     atom.workspace.scan(/<project.*/g, (match) => {
       if (match.filePath.endsWith('pom.xml')) {
@@ -223,4 +225,29 @@ module.exports = {
     });
   }
 
+  dependencyTreeClasspath: funtion() {
+    atom.workspace.scan(/<project.*/g, (match) => {
+      if (match.filePath.endsWith('pom.xml')) {
+        var cp = match.filePath.replace('pom.xml', '.classpath');
+        var cmd = 'mvn dependency:build-classpath -f' + match.filePath + ' -Dmdep.outputFile=' + cp;
+        process.exec(cmd, function(error, stdout, stderr) {
+          if (error) {
+            console.error(`exec error: ${error}`);
+          } else {
+            fs.readFile(cp, function(err, data) {
+              var target = '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;'
+              var locations = target + data;
+              fs.writeFile(cp, locations, (err) => {
+                if (err) {
+                  ui.error(err);
+                }
+              });
+            });
+          }
+          console.debug(`stdout: ${stdout}`);
+          console.debug(`stderr: ${stderr}`);
+        });
+      }
+    });
+  }
 };

--- a/lib/atom-maven.js
+++ b/lib/atom-maven.js
@@ -235,7 +235,10 @@ module.exports = {
             console.error(`exec error: ${error}`);
           } else {
             fs.readFile(cp, function (err, data) {
-              var target = '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;'
+              if(err) {
+                ui.error(err);
+              }
+              var target = '.' + common.fileSeparator + 'target' + common.fileSeparator + 'classes;';
               var locations = target + data;
               fs.writeFile(cp, locations, (err) => {
                 if (err) {


### PR DESCRIPTION
@concon121 Not sure if this is completely ready as I think you would want to encapsulate the maven commands into the node-maven-api project, but here is a thought starter.  I have tried it out on a spring project that pulls in transitive dependencies and it seems to be working. It would allow for the removal of the effective pom code.